### PR TITLE
Updating the stable tag and tested up to version to 6.4

### DIFF
--- a/query-loop-load-more.php
+++ b/query-loop-load-more.php
@@ -3,9 +3,9 @@
  * Plugin Name:             Query Loop Load More
  * Plugin URI:              https://github.com/a8cteam51/query-loop-load-more
  * Description:             Adds a load more option to the Query Loop Pagination block in Gutenberg.
- * Version:                 0.0.2
- * Requires at least:       6.2
- * Tested up to:            6.2
+ * Version:                 1.0.0
+ * Requires at least:       6.4
+ * Tested up to:            6.4
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com

--- a/query-loop-load-more.php
+++ b/query-loop-load-more.php
@@ -4,7 +4,7 @@
  * Plugin URI:              https://github.com/a8cteam51/query-loop-load-more
  * Description:             Adds a load more option to the Query Loop Pagination block in Gutenberg.
  * Version:                 1.0.0
- * Requires at least:       6.4
+ * Requires at least:       6.2
  * Tested up to:            6.4
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects


### PR DESCRIPTION
P2 comment: https://to51.wordpress.com/2023/03/24/pt-task-force-hibt-open-sourcing/#comment-34445

The .org team reviewed the plugin and returned it with some changes we need to make.
Two of them are the stable tag that didn't match between the plugin file and the readme, the second regarded the WordPress tested up to version # .

This PR updates both.

### Test

Install the plugin and confirm everything is working
Check that the plugin version installed (wp admin -> plugins) matches 1.0.0 which is also the same version in the readme file and in the main plugin file
Check the main plugin file and confirm that Tested up to matches the latest release (6.4).