### PR TITLE
Match text domain and plugin slug

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -9,7 +9,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="wpcomsp-qllm"/>
+				<element value="query-loop-load-more"/>
 			</property>
 		</properties>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
       "@makejson"
     ],
     "makepot": "wp i18n make-pot .",
-    "updatepo": "wp i18n update-po ./languages/wpcomsp-qllm.pot",
+    "updatepo": "wp i18n update-po ./languages/query-loop-load-more.pot",
     "makejson": "wp i18n make-json ./languages --pretty-print --no-purge",
     "makemo": "wp i18n make-mo ./languages",
 

--- a/languages/query-loop-load-more.pot
+++ b/languages/query-loop-load-more.pot
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2023-04-18T10:16:28+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
-"X-Domain: wpcomsp-qllm\n"
+"X-Domain: query-loop-load-more\n"
 
 #. Plugin Name of the plugin
 msgid "Query Loop Load More"

--- a/query-loop-load-more.php
+++ b/query-loop-load-more.php
@@ -42,7 +42,7 @@ if ( ! is_file( WPCOMSP_QLLM_PATH . 'vendor/autoload.php' ) ) {
 	add_action(
 		'admin_notices',
 		static function() {
-			$message      = __( 'It seems like <strong>Query Loop Load More</strong> is corrupted. Please reinstall!', 'wpcomsp-qllm' );
+			$message      = __( 'It seems like <strong>Query Loop Load More</strong> is corrupted. Please reinstall!', 'query-loop-load-more' );
 			$html_message = wp_sprintf( '<div class="error notice wpcomsp-qllm-error">%s</div>', wpautop( $message ) );
 			echo wp_kses_post( $html_message );
 		}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -165,13 +165,13 @@ class Plugin {
 		// Button text attribute.
 		$settings['attributes']['loadMoreText'] = array(
 			'type'    => 'string',
-			'default' => __( 'Load More', 'wpcomsp-qllm' ),
+			'default' => __( 'Load More', 'query-loop-load-more' ),
 		);
 
 		// Loading text attribute.
 		$settings['attributes']['loadingText'] = array(
 			'type'    => 'string',
-			'default' => __( 'Loading...', 'wpcomsp-qllm' ),
+			'default' => __( 'Loading...', 'query-loop-load-more' ),
 		);
 
 		return $settings;


### PR DESCRIPTION
In order for the plugin to work properly in WP.org directory and be able to be translated, the text domain and plugin slug must match.