### PR TITLE
Fix Load more button to work with inherited templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ That's it! Your visitors can now load more posts by clicking the load more butto
 
 ## Changelog
 
+### 1.0.3
+* Fix - Loading more posts on "Inherit query from template" 
+
 ### 1.0.2
 * Add - SVN deployment workflow
 * Update - Version and Stable tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "team51-plugin-qllm",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@csstools/postcss-sass": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "team51-plugin-qllm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "team51-plugin-qllm",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@csstools/postcss-sass": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team51-plugin-qllm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A qllm for WP.com Special Projects plugins",
   "author": {
     "name": "WordPress.com Special Projects Team",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpspecialprojects, tommusrhodus
 Tags: gutenberg, editor, block editor, load more, query loop
 Requires at least: 6.2
 Tested up to: 6.6.1
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -29,10 +29,12 @@ Here is how to enable the load more option:
 
 == Changelog ==
 
+= 1.0.3 =
+* Fix - Loading more posts on "Inherit query from template" 
+
 = 1.0.2 =
 * Add - SVN deployment workflow
 * Update - Version and Stable tag
-
 
 = 1.0.1 =
 * Fix - Unify GPL license

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -213,6 +213,7 @@ class Plugin {
 
 		// Get query context for current page number and query Id.
 		$page_key         = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+		$inherit          = isset( $block->context['query']['inherit'] ) ? $block->context['query']['inherit'] : false;
 		$page             = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$block_query      = new \WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		$buttons          = '';
@@ -221,9 +222,9 @@ class Plugin {
 		// Build list of load more links.
 		for ( $i = $page + 1; $i <= $block_query->max_num_pages; $i++ ) {
 			$buttons .= sprintf(
-				'<a class="%s" href="?%s=%d" data-loading-text="%s">%s</a>',
+				$inherit ? '<a class="%s" href="%s/page/%d/" data-loading-text="%s">%s</a>' : '<a class="%s" href="?%s=%d" data-loading-text="%s">%s</a>',
 				'wp-block-button__link wp-element-button wp-load-more__button',
-				esc_html( $page_key ),
+				$inherit ? '' : esc_html( $page_key ),
 				(int) $i,
 				esc_html( $attributes['loadingText'] ),
 				esc_html( $attributes['loadMoreText'] ) . $pagination_arrow


### PR DESCRIPTION
This PR attempts to fix the issues mentioned in #5 by conditionally building the button href to match how the core query block uses pagination links for inherited vs non-inherited template queries.

### Testing
- On a sample site with several posts, set a query block to **_not_** inherit the query from the template.
- On the front-end, test by clicking on the "load more" button.
- Additional, different/non-repeating posts should load.
- Now change the query block to "inherit" query from the template.
- Run the same test again. Additional, different/non-repeating posts should once again load.