### PR TITLE
Initial dotorg deploy workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/.wordpress-org export-ignore
+/node_modules export-ignore
+
+/.* export-ignore
+/composer.lock export-ignore
+/package-lock.json export-ignore
+/package.json export-ignore
+/README.md export-ignore

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to WordPress.org
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Composer Dependencies
+        run: composer install --no-dev
+
+      - name: Install Node Modules and Build Assets
+        run: |
+          npm install
+          npm run build
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: query-loop-load-more
+          DRY_RUN: true


### PR DESCRIPTION
Add testing workflows for deploying to WordPress.org.
Currently set as a manual action, and in dry-run mode.