### PR TITLE
Switch to distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,12 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/node_modules
+
+# Files
+.*
+composer.lock
+package-lock.json
+package.json
+README.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,0 @@
-/.github export-ignore
-/.wordpress-org export-ignore
-/node_modules export-ignore
-
-/.* export-ignore
-/composer.lock export-ignore
-/package-lock.json export-ignore
-/package.json export-ignore
-/README.md export-ignore

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -24,4 +24,3 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: query-loop-load-more
-          DRY_RUN: true


### PR DESCRIPTION
gitattributes respects gitignore, so it blocked the vendor folder and blocks folder from being deployed. The dry run tag was also incorrect and it deployed anyways, so removed it.