### PR TITLE
Fix `$max_pages` bug

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -254,7 +254,7 @@ class Plugin {
 		$page             = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_parameter   = $inherit ? 'paged' : $page_key;
 		$block_query      = $inherit ? $wp_query : new \WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_pages        = '0' === $block->context['query']['pages'] ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
+		$max_pages        = !is_numeric($block->context['query']['pages']) || 0 === (int) $block->context['query']['pages'] ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
 		$button_classes   = $is_infinite
 			? 'wp-load-more__button wp-load-more__infinite-scroll'
 			: 'wp-block-button__link wp-element-button wp-load-more__button';


### PR DESCRIPTION
When first trying out this plugin, I discovered that it would work in the block editor, but would not render at all on the frontend. It appears that as of WP 6.7+, the `$block->context['query']['pages']` value would be an integer rather than a string by default (`0` vs `'0'`). The strict type-checking within `src/Plugin.php` would cause `$max_pages` to always be `0` rather than switching to the value of `$block_query->max_num_pages`, causing the infinite scroll block not to render. The following update I've implemented attempts to accommodate for both `0` and `'0'`.

Here's the system information of the WP instance I used to test this update. It's essentially just bare WP 6.7.2 with Twenty Twenty-Five and this plugin.

```
### wp-core ###

version: 6.7.2
site_language: en_US
user_language: en_US
timezone: +00:00
permalink: /%postname%/
https_status: false
multisite: false
user_registration: 0
blog_public: 1
default_comment_status: open
environment_type: local
user_count: 1
dotorg_communication: true

### wp-paths-sizes ###

wordpress_path: .../Local Sites/wordpress-67/app/public
wordpress_size: 56.96 MB (59731626 bytes)
uploads_path: .../Local Sites/wordpress-67/app/public/wp-content/uploads
uploads_size: 1.98 MB (2077788 bytes)
themes_path: .../Local Sites/wordpress-67/app/public/wp-content/themes
themes_size: 13.56 MB (14221428 bytes)
plugins_path: .../Local Sites/wordpress-67/app/public/wp-content/plugins
plugins_size: 86.27 MB (90463402 bytes)
fonts_path: .../Local Sites/wordpress-67/app/public/wp-content/uploads/fonts
fonts_size: directory not found
database_size: 2.70 MB (2834432 bytes)
total_size: 161.48 MB (169328676 bytes)

### wp-active-theme ###

name: Twenty Twenty-Five (twentytwentyfive)
version: 1.1
author: the WordPress team
author_website: https://wordpress.org
parent_theme: none
theme_features: core-block-patterns, post-thumbnails, responsive-embeds, editor-styles, html5, automatic-feed-links, widgets-block-editor, block-templates, post-formats, editor-style
theme_path: .../Local Sites/wordpress-67/app/public/wp-content/themes/twentytwentyfive
auto_update: Disabled

### wp-themes-inactive (2) ###

Twenty Twenty-Four: version: 1.3, author: the WordPress team, Auto-updates disabled
Twenty Twenty-Three: version: 1.6, author: the WordPress team, Auto-updates disabled

### wp-plugins-active (1) ###

Query Loop Load More: version: 1.0.11, author: WordPress.com Special Projects, Auto-updates disabled

### wp-plugins-inactive (1) ###

Gutenberg: version: 20.5.0, author: Gutenberg Team, Auto-updates disabled

### wp-media ###

image_editor: WP_Image_Editor_Imagick
imagick_module_version: 1808
imagemagick_version: ImageMagick 7.1.0-10 Q16 x86_64 2021-10-05 https://imagemagick.org
imagick_version: 3.7.0
file_uploads: 1
post_max_size: 1000M
upload_max_filesize: 300M
max_effective_size: 300 MB
max_file_uploads: 20
imagick_limits: 
	imagick::RESOURCETYPE_AREA: 63 GB
	imagick::RESOURCETYPE_DISK: 9.2233720368548E+18
	imagick::RESOURCETYPE_FILE: 6144
	imagick::RESOURCETYPE_MAP: 63 GB
	imagick::RESOURCETYPE_MEMORY: 31 GB
	imagick::RESOURCETYPE_THREAD: 1
	imagick::RESOURCETYPE_TIME: 9.2233720368548E+18
imagemagick_file_formats: 3FR, 3G2, 3GP, AAI, AI, APNG, ART, ARW, ASHLAR, AVI, AVIF, AVS, BGR, BGRA, BGRO, BIE, BMP, BMP2, BMP3, BRF, CAL, CALS, CANVAS, CAPTION, CIN, CIP, CLIP, CMYK, CMYKA, CR2, CR3, CRW, CUBE, CUR, CUT, DATA, DCM, DCR, DCRAW, DCX, DDS, DFONT, DJVU, DNG, DOT, DPX, DXT1, DXT5, EPDF, EPI, EPS, EPS2, EPS3, EPSF, EPSI, EPT, EPT2, EPT3, ERF, EXR, FARBFELD, FAX, FF, FILE, FITS, FL32, FLV, FRACTAL, FTP, FTS, G3, G4, GIF, GIF87, GRADIENT, GRAY, GRAYA, GROUP4, GV, HALD, HDR, HEIC, HEIF, HISTOGRAM, HRZ, HTM, HTML, HTTP, HTTPS, ICB, ICO, ICON, IIQ, INFO, INLINE, IPL, ISOBRL, ISOBRL6, J2C, J2K, JBG, JBIG, JNG, JNX, JP2, JPC, JPE, JPEG, JPG, JPM, JPS, JPT, JSON, K25, KDC, KERNEL, LABEL, M2V, M4V, MAC, MAP, MASK, MAT, MATTE, MEF, MIFF, MKV, MNG, MONO, MOV, MP4, MPC, MPEG, MPG, MRW, MSL, MSVG, MTV, MVG, NEF, NRW, NULL, ORA, ORF, OTB, OTF, PAL, PALM, PAM, PANGO, PATTERN, PBM, PCD, PCDS, PCL, PCT, PCX, PDB, PDF, PDFA, PEF, PES, PFA, PFB, PFM, PGM, PGX, PHM, PICON, PICT, PIX, PJPEG, PLASMA, PNG, PNG00, PNG24, PNG32, PNG48, PNG64, PNG8, PNM, POCKETMOD, PPM, PS, PS2, PS3, PSB, PSD, PTIF, PWP, RADIAL-GRADIENT, RAF, RAS, RAW, RGB, RGB565, RGBA, RGBO, RGF, RLA, RLE, RMF, RW2, SCR, SCT, SFW, SGI, SHTML, SIX, SIXEL, SPARSE-COLOR, SR2, SRF, STEGANO, SUN, SVG, SVGZ, TEXT, TGA, THUMBNAIL, TIFF, TIFF64, TILE, TIM, TM2, TTC, TTF, TXT, UBRL, UBRL6, UIL, UYVY, VDA, VICAR, VID, VIFF, VIPS, VST, WBMP, WEBM, WEBP, WMF, WMV, WMZ, WPG, X, X3F, XBM, XC, XCF, XPM, XPS, XV, XWD, YAML, YCbCr, YCbCrA, YUV
gd_version: bundled (2.1.0 compatible)
gd_formats: GIF, JPEG, PNG, WebP, BMP, AVIF, XPM
ghostscript_version: 10.04.0

### wp-server ###

server_architecture: Linux 6.12.20-amd64 x86_64
httpd_software: nginx/1.26.1
php_version: 8.3.17 64bit
php_sapi: fpm-fcgi
max_input_variables: 4000
time_limit: 1200
memory_limit: 256M
max_input_time: 600
upload_max_filesize: 300M
php_post_max_size: 1000M
curl_version: 7.81.0 OpenSSL/3.0.2
suhosin: false
imagick_availability: true
pretty_permalinks: true
htaccess_extra_rules: false
current: 2025-03-28T16:54:39+00:00
utc-time: Friday, 28-Mar-25 16:54:39 UTC
server-time: 2025-03-28T16:54:38+00:00

### wp-database ###

extension: mysqli
server_version: 8.0.16
client_version: mysqlnd 8.3.17
max_allowed_packet: 16777216
max_connections: 151

### wp-constants ###

WP_HOME: undefined
WP_SITEURL: undefined
WP_CONTENT_DIR: .../Local Sites/wordpress-67/app/public/wp-content
WP_PLUGIN_DIR: .../Local Sites/wordpress-67/app/public/wp-content/plugins
WP_MEMORY_LIMIT: 40M
WP_MAX_MEMORY_LIMIT: 256M
WP_DEBUG: false
WP_DEBUG_DISPLAY: true
WP_DEBUG_LOG: false
SCRIPT_DEBUG: false
WP_CACHE: false
CONCATENATE_SCRIPTS: undefined
COMPRESS_SCRIPTS: undefined
COMPRESS_CSS: undefined
WP_ENVIRONMENT_TYPE: local
WP_DEVELOPMENT_MODE: undefined
DB_CHARSET: utf8
DB_COLLATE: undefined

### wp-filesystem ###

wordpress: writable
wp-content: writable
uploads: writable
plugins: writable
themes: writable
fonts: not writable
```