### PR TITLE
Compare block context query pages as integer instead of string

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -254,7 +254,7 @@ class Plugin {
 		$page             = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_parameter   = $inherit ? 'paged' : $page_key;
 		$block_query      = $inherit ? $wp_query : new \WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_pages        = '0' === $block->context['query']['pages'] ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
+		$max_pages        = 0 === $block->context['query']['pages'] ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
 		$button_classes   = $is_infinite
 			? 'wp-load-more__button wp-load-more__infinite-scroll'
 			: 'wp-block-button__link wp-element-button wp-load-more__button';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -254,7 +254,7 @@ class Plugin {
 		$page             = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_parameter   = $inherit ? 'paged' : $page_key;
 		$block_query      = $inherit ? $wp_query : new \WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_pages        = 0 === $block->context['query']['pages'] ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
+		$max_pages        = empty( $block->context['query']['pages'] ) ? $block_query->max_num_pages : (int) $block->context['query']['pages'];
 		$button_classes   = $is_infinite
 			? 'wp-load-more__button wp-load-more__infinite-scroll'
 			: 'wp-block-button__link wp-element-button wp-load-more__button';


### PR DESCRIPTION
Bug fixed: Load More button is missing on Jeff Gothelf site. Also, Infinite scroll is not working on other test site.

The root cause is that the value of `$block->context['query']['pages']` is an integer, so the `===` comparison with the string `'0'` returns always false.

This end up in `$max_pages` being assigned with `(int) $block->context['query']` (ie: 0), instead of the value in `$block_query->max_num_pages` which is something greater than zero, causing the Load More to silently fail.

Incident: https://github.com/a8cteam51/team51-dev-requests/issues/5584