### PR TITLE
Fix pagination reset issue for inherited queries by using get_query_var

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -251,7 +251,9 @@ class Plugin {
 		$inherit          = $block->context['query']['inherit'] ?? false;
 		$is_infinite      = $attributes['infiniteScroll'] ?? false;
 		$is_update_url    = $attributes['updateUrl'] ?? false;
-		$page             = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page = $inherit
+			? ( get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1 )
+			: ( empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_parameter   = $inherit ? 'paged' : $page_key;
 		$block_query      = $inherit ? $wp_query : new \WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		$max_pages        = empty( $block->context['query']['pages'] ) ? $block_query->max_num_pages : (int) $block->context['query']['pages'];


### PR DESCRIPTION
This PR addresses [Issue #50](https://github.com/a8cteam51/query-loop-load-more/issues/50), where pagination state is lost when using “Load More” or “Infinite Scroll” with Update URL enabled on archive pages that rely on inherited queries.

The fix uses WordPress’s native get_query_var('paged') to determine the current page when dealing with inherited queries, falling back to $_GET for non-inherited ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination handling to ensure the correct page number and query are used based on the context, leading to more accurate navigation in inherited and non-inherited scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->