### PR TITLE
Update plugin author to Automattic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
   "license": "GPL-3.0-or-later",
   "authors": [
     {
-      "name": "WordPress.com Special Projects Team",
-      "homepage": "https://wpspecialprojects.wordpress.com/"
+      "name": "Automattic",
+      "homepage": "https://automattic.com/"
     },
     {
       "name": "Contributors",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.17",
   "description": "A qllm for WP.com Special Projects plugins",
   "author": {
-    "name": "WordPress.com Special Projects Team",
-    "url": "https://wpspecialprojects.wordpress.com"
+    "name": "Automattic",
+    "url": "https://automattic.com"
   },
   "license": "GPL-3.0-or-later",
   "keywords": [

--- a/query-loop-load-more.php
+++ b/query-loop-load-more.php
@@ -8,8 +8,8 @@
  * Requires at least:       6.2
  * Tested up to:            6.9
  * Requires PHP:            8.0
- * Author:                  WordPress.com Special Projects
- * Author URI:              https://wpspecialprojects.wordpress.com
+ * Author:                  Automattic
+ * Author URI:              https://automattic.com
  * License:                 GPLv3 or later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:             query-loop-load-more

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Query Loop Load More ===
-Contributors: wpspecialprojects, tommusrhodus, npagazani, geoffguillain, tiagonoronha, tiagonoronha, nateallen, glynnquelch, dhansondesigns, mlaetitia, fmfernandes, robrobsn, kimclow, dhansondesigns
+Contributors: automattic, wpspecialprojects, tommusrhodus, npagazani, geoffguillain, tiagonoronha, nateallen, glynnquelch, dhansondesigns, mlaetitia, fmfernandes, robrobsn, kimclow
 Tags: block editor, query loop, gutenberg, full-site-editing, load more
 Requires at least: 6.2
 Tested up to: 6.9


### PR DESCRIPTION
## Summary

This plugin should be attributed to Automattic rather than "Automattic Special Projects." This PR updates the author metadata and contributor listing accordingly, while keeping WordPress.com Special Projects listed as a developer.

## Changes

- **`readme.txt`** — Added `automattic` as the first entry in `Contributors:`, so the "Contributors & Developers" section on wp.org lists Automattic first, then `wpspecialprojects`, then everyone else. Also removed two duplicate usernames (`tiagonoronha`, `dhansondesigns`).
- **`query-loop-load-more.php`** — `Author` → `Automattic`, `Author URI` → `https://automattic.com`.
- **`composer.json`** — First author → `Automattic` / `https://automattic.com/`.
- **`package.json`** — Author → `Automattic` / `https://automattic.com`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata and attribution information across package and plugin files to reflect current organizational details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->